### PR TITLE
added sync back in and pass nil values to latest api

### DIFF
--- a/gfapi/fd.go
+++ b/gfapi/fd.go
@@ -45,39 +45,13 @@ func (fd *Fd) Fstat(stat *syscall.Stat_t) error {
 //
 // Returns error on failure
 func (fd *Fd) Fsync() error {
+	// the 2 nil parameters here are stat parameters. These are nil checked in the C library so it's OK to pass nil.
 	ret, err := C.glfs_fsync(fd.fd, nil, nil)
 	if ret < 0 {
 		return err
 	}
 	return nil
 }
-
-// Ftruncate truncates the size of the Fd to the given size
-//
-// Returns error on failure
-//func (fd *Fd) Ftruncate(size int64) error {
-//	_, err := C.glfs_ftruncate(fd.fd, C.off_t(size))
-//
-//	return err
-//}
-
-// Pread reads at most len(b) bytes into b from offset off in Fd
-//
-// Returns number of bytes read on success and error on failure
-//func (fd *Fd) Pread(b []byte, off int64) (int, error) {
-//	n, err := C.glfs_pread(fd.fd, unsafe.Pointer(&b[0]), C.size_t(len(b)), C.off_t(off), 0)
-//
-//	return int(n), err
-//}
-
-// Pwrite writes len(b) bytes from b into the Fd from offset off
-//
-// Returns number of bytes written on success and error on failure
-//func (fd *Fd) Pwrite(b []byte, off int64) (int, error) {
-//	n, err := C.glfs_pwrite(fd.fd, unsafe.Pointer(&b[0]), C.size_t(len(b)), C.off_t(off), 0)
-//
-//	return int(n), err
-//}
 
 // Read reads at most len(b) bytes into b from Fd
 //

--- a/gfapi/fd.go
+++ b/gfapi/fd.go
@@ -44,13 +44,13 @@ func (fd *Fd) Fstat(stat *syscall.Stat_t) error {
 // Fsync performs an fsync on the Fd
 //
 // Returns error on failure
-//func (fd *Fd) Fsync() error {
-//	ret, err := C.glfs_fsync(fd.fd)
-//	if ret < 0 {
-//		return err
-//	}
-//	return nil
-//}
+func (fd *Fd) Fsync() error {
+	ret, err := C.glfs_fsync(fd.fd, nil, nil)
+	if ret < 0 {
+		return err
+	}
+	return nil
+}
 
 // Ftruncate truncates the size of the Fd to the given size
 //

--- a/gfapi/file.go
+++ b/gfapi/file.go
@@ -125,11 +125,11 @@ func (f *File) Stat() (os.FileInfo, error) {
 }
 
 // Sync commits the file to the storage
-//
-// Returns error on failure
-//func (f *File) Sync() error {
-//	return f.Fd.Fsync()
-//}
+
+//Returns error on failure
+func (f *File) Sync() error {
+	return f.Fd.Fsync()
+}
 
 // Truncate changes the size of the file
 //

--- a/gfapi/file.go
+++ b/gfapi/file.go
@@ -80,13 +80,6 @@ func (f *File) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
-// ReadAt reads atmost len(b) bytes into b starting from offset off
-//
-// Returns number of bytes read and an error if any
-//func (f *File) ReadAt(b []byte, off int64) (int, error) {
-//	return f.Fd.Pread(b, off)
-//}
-
 // Readdir returns the information of files in a directory.
 //
 // n is the maximum number of items to return. If there are more items than
@@ -131,13 +124,6 @@ func (f *File) Sync() error {
 	return f.Fd.Fsync()
 }
 
-// Truncate changes the size of the file
-//
-// Returns error on failure
-//func (f *File) Truncate(size int64) error {
-//	return f.Fd.Ftruncate(size)
-//}
-
 // Write writes len(b) bytes to the file
 //
 // Returns number of bytes written and an error if any
@@ -155,13 +141,6 @@ func (f *File) Write(b []byte) (n int, err error) {
 	}
 	return n, err
 }
-
-// WriteAt writes len(b) bytes to the file starting at offset off
-//
-// Returns number of bytes written and an error if any
-//func (f *File) WriteAt(b []byte, off int64) (int, error) {
-//	return f.Fd.Pwrite(b, off)
-//}
 
 // WriteString writes the contents of string s to the file
 //


### PR DESCRIPTION
So that we can use `fsync` In our code, this PR fixes the function by passing 2 nil parameters to the new API signature. The API does a nil check so it's safe to do.