### PR TITLE
Add fdatasync

### DIFF
--- a/gfapi/fd.go
+++ b/gfapi/fd.go
@@ -53,6 +53,18 @@ func (fd *Fd) Fsync() error {
 	return nil
 }
 
+// FDatasync performs an fdatasync on the Fd
+//
+// Returns error on failure
+func (fd *Fd) FDatasync() error {
+	// the 2 nil parameters here are stat parameters. These are nil checked in the C library so it's OK to pass nil.
+	ret, err := C.glfs_fdatasync(fd.fd, nil, nil)
+	if ret < 0 {
+		return err
+	}
+	return nil
+}
+
 // Read reads at most len(b) bytes into b from Fd
 //
 // Returns number of bytes read on success and error on failure

--- a/gfapi/file.go
+++ b/gfapi/file.go
@@ -124,8 +124,8 @@ func (f *File) Sync() error {
 	return f.Fd.Fsync()
 }
 
-// DataSync commits data changes to storage
-//Returns error on failure
+// DataSync commits data changes only to storage. Does not commit metadata changes.
+// Returns error on failure
 func (f *File) DataSync() error {
 	return f.Fd.FDatasync()
 }

--- a/gfapi/file.go
+++ b/gfapi/file.go
@@ -124,6 +124,13 @@ func (f *File) Sync() error {
 	return f.Fd.Fsync()
 }
 
+// DataSync commits data changes to storage
+//Returns error on failure
+func (f *File) DataSync() error {
+	return f.Fd.FDatasync()
+}
+
+
 // Write writes len(b) bytes to the file
 //
 // Returns number of bytes written and an error if any


### PR DESCRIPTION
This PR will allow us to call `fdatasync` on a file once we have finished reading it, instead of `fsync`. 

`fsync` will commit data and metadata. It looks like we seem to be committing metadata after reading each file, which is adding pressure to Gluster. Instead, using `fdatasync` will only commit data changes (which we aren't doing because we are only reading) and it won't commit metadata changes.

This has been tested with the Event Storage Service in dev and events are read ok, and the volumes are unmounted without error.